### PR TITLE
Removed unnecessary "err" of naked return

### DIFF
--- a/gen/encode.go
+++ b/gen/encode.go
@@ -101,7 +101,7 @@ func (e *encodeGen) appendraw(bts []byte) {
 		}
 		e.p.printf("0x%x", b)
 	}
-	e.p.print(")\nif err != nil { return err }")
+	e.p.print(")\nif err != nil { return }")
 }
 
 func (e *encodeGen) structmap(s *Struct) {


### PR DESCRIPTION
The generated encode functions that have a naked return (simply "return") where the function returns an error type all have the "err" variable declared as a named return (as it is here in the func "appendraw"). But this is the only place where the "return" is followed by a " err"; this is unnecessary because the return value is named in the function signature. I've been manually removing the extra space-err in every .Append block because they make the code inconsistent and are very annoying.